### PR TITLE
Fix for issue deserializing base64Binary[] datatypes

### DIFF
--- a/src/main/java/org/doublecloud/ws/util/ReflectUtil.java
+++ b/src/main/java/org/doublecloud/ws/util/ReflectUtil.java
@@ -123,6 +123,28 @@ public class ReflectUtil {
     }
 
     private static byte[] toByteArray(List<String> values) {
+        if (values.stream().anyMatch(s -> s.length() > 16)) {
+            // Handle array of base64Binary
+            byte[][] arrays = new byte[values.size()][];
+            int length = 0;
+            for (int i = 0; i < values.size(); i++) {
+                final byte[] test = tryBase64Decode(values.get(i));
+                if (test != null) {
+                    arrays[i] = test;
+                    length += arrays[i].length;
+                }
+            }
+
+            byte[] ret = new byte[length];
+            int offset = 0;
+            for (int i = 0; i < arrays.length; i++) {
+                System.arraycopy(arrays[i], 0, ret, offset, arrays[i].length);
+                offset += arrays[i].length;
+            }
+
+            return ret;
+        }
+
         if(values.size() == 1) {
             final byte[] test = tryBase64Decode(values.get(0));
             if (test != null) {


### PR DESCRIPTION
The VirtualTPM device type uses byte[] but the actual datatype is base64Binary[]. When we try to serialize this the base64 check fails (as it only checks to see whether "values" has one entry) so falls back to the original serialization, which then fails with a NumberFormatException