### PR TITLE
Fix NullPointerException being thrown

### DIFF
--- a/src/main/java/com/vmware/vim/VirtualMachineDeviceManager.java
+++ b/src/main/java/com/vmware/vim/VirtualMachineDeviceManager.java
@@ -31,12 +31,14 @@ package com.vmware.vim;
 
 import com.vmware.vim25.*;
 import com.vmware.vim25.mo.*;
+import static org.doublecloud.ws.util.TypeUtil.asNullSafeList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -303,7 +305,7 @@ public class VirtualMachineDeviceManager {
     }
 
     public VirtualDisk findHardDisk(String diskName) {
-        VirtualDevice[] devices = getAllVirtualDevices();
+        List<VirtualDevice> devices = getAllVirtualDevices();
 
         for (final VirtualDevice device : devices) {
             if (device instanceof VirtualDisk) {
@@ -327,7 +329,7 @@ public class VirtualMachineDeviceManager {
 
         if (controller.device.length < maxNodes) {
             List<Integer> usedNodeList = new ArrayList<Integer>();
-            VirtualDevice[] devices = getAllVirtualDevices();
+            List<VirtualDevice> devices = getAllVirtualDevices();
 
             // If this is SCSI controller then its controller also occupies one node.
             if (controller instanceof VirtualSCSIController) {
@@ -666,16 +668,16 @@ public class VirtualMachineDeviceManager {
      *
      * @return VirtualDevice[]
      */
-    public VirtualDevice[] getAllVirtualDevices() {
+    public List<VirtualDevice> getAllVirtualDevices() {
         VirtualDevice[] devices = (VirtualDevice[]) vm.getPropertyByPath("config.hardware.device");
-        return devices;
+        return asNullSafeList(devices);
     }
 
     @SuppressWarnings("unchecked")
     public <T extends VirtualDevice> List<T> getVirtualDevicesOfType(Class<T> clazz) {
         List<T> result = new ArrayList<T>();
 
-        VirtualDevice[] devices = getAllVirtualDevices();
+        List<VirtualDevice> devices = getAllVirtualDevices();
 
         for (VirtualDevice dev : devices) {
             if (clazz.isInstance(dev)) // dynamic equivalent of instanceof operator
@@ -691,7 +693,7 @@ public class VirtualMachineDeviceManager {
             throw new IllegalArgumentException("name must not be null!");
         }
 
-        VirtualDevice[] devices = this.getAllVirtualDevices();
+        List<VirtualDevice> devices = this.getAllVirtualDevices();
 
         for (VirtualDevice device : devices) {
             VirtualDeviceBackingInfo bi = device.getBacking();

--- a/src/main/java/com/vmware/vim25/mo/InventoryNavigator.java
+++ b/src/main/java/com/vmware/vim25/mo/InventoryNavigator.java
@@ -101,10 +101,12 @@ public class InventoryNavigator {
 
         final List<ObjectContent> allObjects = new ArrayList<>(5000);
         RetrieveResult result = pc.retrievePropertiesEx(List.of(spec), retrieveOptions);
-        allObjects.addAll(result.getObjectList());
-        while (result.getToken() != null) {
-            result = pc.continueRetrievePropertiesEx(result.getToken());
+        if (result != null) {
             allObjects.addAll(result.getObjectList());
+            while (result.getToken() != null) {
+                result = pc.continueRetrievePropertiesEx(result.getToken());
+                allObjects.addAll(result.getObjectList());
+            }
         }
         return allObjects;
     }


### PR DESCRIPTION
In our client code we have seen the following at a customer site:

[03/02/2025 06:33:44+0000] :: [E] :: VSphereServiceClient : discoverClusters :: java.lang.NullPointerException: Cannot invoke "com.vmware.vim25.RetrieveResult.getObjects()" because "result" is null :: line: 1281

This pull request adds some handling for this to return an empty array instead of throwing a NullPointerException. I'm not entirely sure why the result object is null itself unless there is some kind of environmental issue causing the XML response from the API to be garbled?

I've also done a small refactor to VirtualMachineDeviceManager to return List<VirtualDevice> instead of VirtualDevice[] for consistency with some of the other refactoring that's taken place in the library.